### PR TITLE
Reduce next build peak CPU and memory usage

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -8,9 +8,6 @@ const nextConfig = {
     serverSourceMaps: false,
   },
   productionBrowserSourceMaps: false,
-  eslint: {
-    ignoreDuringBuilds: true,
-  },
   images: {
     remotePatterns: [
       {

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,16 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  // Cap build parallelism so next build uses less peak CPU/RAM on small hosts.
+  experimental: {
+    cpus: 1,
+    workerThreads: false,
+    webpackMemoryOptimizations: true,
+    serverSourceMaps: false,
+  },
+  productionBrowserSourceMaps: false,
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
   images: {
     remotePatterns: [
       {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "NODE_OPTIONS='--max-old-space-size=3072' next build",
     "start": "next start",
     "lint": "next lint"
   },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Limits `next build` resource pressure on small hosts without changing app behavior.

### Changes
- Cap webpack workers (`experimental.cpus: 1`, `workerThreads: false`)
- Enable `experimental.webpackMemoryOptimizations`
- Disable production/server source maps during build
- Cap Node heap at 3GB for the build script (`NODE_OPTIONS=--max-old-space-size=3072`)

### Verified
- `npm run build` succeeds on Next.js 16.3.0; static generation used 1 worker

### CI note
`guardrails/scan` is failing with **“Scan skipped, plan limit reached. Contact sales.”** — this is a GuardRails SaaS quota/permissions issue, not a defect in this PR. Vercel + GitGuardian pass. Unblock by upgrading/resetting GuardRails quota, granting Checks Read & Write for fail-open skips, or disabling the app for this repo.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe504-3339-7d48-9c6d-21d2372ba3dd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe504-3339-7d48-9c6d-21d2372ba3dd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

