### PR TITLE
fix: distinguish "backend is down" from "TMDB not configured"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,3 +64,13 @@ Route → service function in `src/services/` → `export const revalidate` → 
 
 Index/aggregator only; no media is hosted here.
 
+
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
+<!-- END:nextjs-agent-rules -->

--- a/src/app/movie/page.tsx
+++ b/src/app/movie/page.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next";
 import { getMovieHome } from "@/services/movie";
+import { isBackendReachable } from "@/lib/api";
+import BackendDown from "@/components/media/backend-down";
 import PageShell from "@/components/media/page-shell";
 import PosterCard from "@/components/media/poster-card";
 import PosterGrid from "@/components/media/poster-grid";
@@ -37,6 +39,10 @@ export default async function MovieHomePage() {
   const empty =
     home.trending.length + home.popular_movies.length + home.popular_tv.length === 0;
 
+  // Only pay for the health check when there is nothing to show — an empty
+  // section has two very different causes and they need different advice.
+  const backendUp = empty ? await isBackendReachable() : true;
+
   return (
     <PageShell
       title="Film & Serial"
@@ -52,10 +58,12 @@ export default async function MovieHomePage() {
         </div>
       }
     >
-      {empty ? (
+      {empty && !backendUp ? <BackendDown /> : null}
+
+      {empty && backendUp ? (
         <EmptyState
           title="Sumber film belum dikonfigurasi"
-          description="Isi TMDB_ACCESS_TOKEN di backend untuk mengaktifkan bagian ini."
+          description="Backend berjalan, tapi TMDB_ACCESS_TOKEN belum diisi. Tambahkan di otakudesu-be/.env lalu restart backend."
           action={{ href: "/", label: "Kembali ke beranda" }}
         />
       ) : null}

--- a/src/components/media/backend-down.tsx
+++ b/src/components/media/backend-down.tsx
@@ -1,0 +1,25 @@
+/**
+ * Shown when the API itself cannot be reached, as opposed to a domain simply
+ * having no data. The distinction matters: one is fixed by starting a service,
+ * the other by setting a token.
+ */
+export default function BackendDown() {
+  return (
+    <div className="border p-8 text-center sm:p-12">
+      <p className="eyebrow text-destructive">Backend tidak merespons</p>
+      <h2 className="font-display mt-2 text-xl font-extrabold tracking-tight uppercase sm:text-2xl">
+        Tidak bisa terhubung ke API
+      </h2>
+      <p className="text-muted-foreground mx-auto mt-3 max-w-md text-sm">
+        Frontend berjalan, tapi backend-nya belum hidup. Jalankan servis API lebih dulu, lalu muat
+        ulang halaman ini.
+      </p>
+      <pre className="bg-muted mx-auto mt-4 max-w-md overflow-x-auto border p-3 text-left font-mono text-xs">
+        cd otakudesu-be{"\n"}bun run start
+      </pre>
+      <p className="text-muted-foreground mt-3 font-mono text-xs">
+        Default: http://localhost:3000 · atur lewat API_BASE_URL
+      </p>
+    </div>
+  );
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -69,3 +69,23 @@ export async function apiOr<T>(path: string, fallback: T, options: Options = {})
 export function apiBaseUrl(): string {
   return BASE_URL;
 }
+
+/**
+ * Cheap liveness check against the backend.
+ *
+ * Used only to tell two very different failures apart in the UI: "the backend
+ * is down" and "the backend is up but this domain has no data". Rendering the
+ * same empty state for both sent a real user hunting through their `.env` when
+ * the actual problem was a service that had not been started.
+ */
+export async function isBackendReachable(): Promise<boolean> {
+  try {
+    const response = await fetch(`${BASE_URL}/api/health`, {
+      cache: "no-store",
+      signal: AbortSignal.timeout(3000),
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
The film section rendered "Sumber film belum dikonfigurasi" whenever it had no data — including when the backend simply was not running. That sent a user who had already set TMDB_ACCESS_TOKEN correctly hunting through their .env for a problem that was not there.

The two failures need different advice, so the page now checks liveness before choosing a message: an unreachable API says so and shows the command to start it, while a reachable API with no data still points at the token. The health check only runs when the section is already empty, so the happy path is unaffected.

## What does this change?

<!-- One or two sentences. Link the issue if there is one. -->

## Screenshots

<!-- Required for any visual change. Light and dark mode if the change affects both. -->

## Checklist

- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] `bun test` passes
- [ ] Pages stay Server Components unless a browser API is genuinely required
- [ ] `generateMetadata` uses real data, not the slug
- [ ] No new `rounded-*` expectations — the design is squared by design
- [ ] New indexable routes added to `src/app/sitemap.ts`
